### PR TITLE
Update `WithLatestFrom`

### DIFF
--- a/CombinePublisherBooster/WithLatestFrom/WithLatestFrom.swift
+++ b/CombinePublisherBooster/WithLatestFrom/WithLatestFrom.swift
@@ -21,8 +21,8 @@ public extension Publisher {
 }
 
 /// Private implementation for creating `WithLatsetFrom` similar to [RxSwift](https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Observables/WithLatestFrom.swift)
-private struct WithLatestFromPublisher<A, B>: Publisher where A: Publisher, B: Publisher,
-                                                              A.Failure == B.Failure {
+struct WithLatestFromPublisher<A, B>: Publisher where A: Publisher, B: Publisher,
+                                                      A.Failure == B.Failure {
 
   init(_ publisher: A, _ other: B) {
     self.publisher = publisher
@@ -45,7 +45,7 @@ private struct WithLatestFromPublisher<A, B>: Publisher where A: Publisher, B: P
 }
 
 /// Private extension used to declare the subscription class.
-private extension WithLatestFromPublisher {
+extension WithLatestFromPublisher {
   /// Represents a subscription to the `WithLatestFromPublisher`
   final class WithLatestFromPublisherSubscription<S: Subscriber>: Subscription where A.Failure == B.Failure,
                                                                                      A.Failure == S.Failure,
@@ -75,7 +75,7 @@ private extension WithLatestFromPublisher {
       // We don't care what the particular demand is, we connect to the other publisher to
       // start capturing values.
       other.sink { _ in
-        /// We don't care about the `latestFrom` completing. We just want the values.
+        // We don't care about the `latestFrom` completing. We just want the values.
       } receiveValue: { [weak self] value in
         // If self no longer exists, don't do any work!
         guard let self else { return }
@@ -88,6 +88,8 @@ private extension WithLatestFromPublisher {
       publisher.sink { [weak self] completion in
         guard let self else { return }
         subscriber?.receive(completion: completion)
+        // The subscriber can be released now, as we don't expect future values anymore.
+        subscriber = nil
       } receiveValue: { [weak self] value in
         // If self no longer exists, don't do any work!
         guard let self else { return }

--- a/CombinePublisherBooster/WithLatestFrom/WithLatestFrom.swift
+++ b/CombinePublisherBooster/WithLatestFrom/WithLatestFrom.swift
@@ -20,7 +20,7 @@ public extension Publisher {
   }
 }
 
-/// Private implementation for creating `WithLatsetFrom` similar to [RxSwift](https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Observables/WithLatestFrom.swift)
+/// Implementation for creating `WithLatsetFrom` similar to [RxSwift](https://github.com/ReactiveX/RxSwift/blob/main/RxSwift/Observables/WithLatestFrom.swift)
 struct WithLatestFromPublisher<A, B>: Publisher where A: Publisher, B: Publisher,
                                                       A.Failure == B.Failure {
 
@@ -44,7 +44,7 @@ struct WithLatestFromPublisher<A, B>: Publisher where A: Publisher, B: Publisher
   }
 }
 
-/// Private extension used to declare the subscription class.
+/// Extension used to declare the subscription class.
 extension WithLatestFromPublisher {
   /// Represents a subscription to the `WithLatestFromPublisher`
   final class WithLatestFromPublisherSubscription<S: Subscriber>: Subscription where A.Failure == B.Failure,

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "combinetestingbooster",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftBoosterPack/CombineTestingBooster.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "0aeed7d1a1c6059156d84f562718e0b4e687ffc3"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,9 @@ let package = Package(
       targets: ["CombinePublisherBooster"]
     ),
   ],
+  dependencies: [
+    .package(url: "https://github.com/SwiftBoosterPack/CombineTestingBooster.git", branch: "main")
+  ],
   targets: [
     .target(
       name: "CombinePublisherBooster",
@@ -21,7 +24,10 @@ let package = Package(
     ),
     .testTarget(
       name: "CombinePublisherBoosterTests",
-      dependencies: ["CombinePublisherBooster"],
+      dependencies: [
+        "CombinePublisherBooster",
+        .product(name: "CombineTesting", package: "CombineTestingBooster")
+      ],
       path: "CombinePublisherBoosterTests"
     ),
   ]


### PR DESCRIPTION
- Make the declaration internal so that it is accessible to testing
- Validate that the subscription also properly deallocates
  - Add more aggressive releasing of the `subscriber`
  - Test shows that if demand is not created (to receive the upstream value) then a retain cycle can occur.